### PR TITLE
Center text and add copyright notice from SAM

### DIFF
--- a/tts.system.s
+++ b/tts.system.s
@@ -46,8 +46,8 @@ HOME    := $FC58
 COUT    := $FDED
 
 message:
-        .byte   "S.A.M. The Software Automatic Mouth", $0D
-        .byte   "By DON'T ASK Computer Software", $0D
+        .byte   " S.A.M. - The Software Automatic Mouth", $0D
+        .byte   "By DON'T ASK Computer Software  (C) 1982", $0D, $0D
         .byte   0
 
 default:
@@ -176,7 +176,7 @@ start:
         sta     SAM_SPEED
         lda     #72
         sta     SAM_PITCH
-        lda     #0
+        lda     #255
         sta     SAM_ECHO
         lda     #255
         sta     SAM_REC

--- a/tts.system.s
+++ b/tts.system.s
@@ -176,7 +176,7 @@ start:
         sta     SAM_SPEED
         lda     #72
         sta     SAM_PITCH
-        lda     #255
+        lda     #0
         sta     SAM_ECHO
         lda     #255
         sta     SAM_REC


### PR DESCRIPTION
Some title formatting. "C 1982" is included in the SAM binary, so including it here. The extra space after the title text is in case echo mode is turned on, for clarity.